### PR TITLE
CSmartPtr; removed in favour of std::shared_ptr

### DIFF
--- a/cyrusauthldap.cpp
+++ b/cyrusauthldap.cpp
@@ -103,7 +103,7 @@ public:
 		return true;
 	}
 
-	virtual EModRet OnLoginAttempt(CSmartPtr<CAuthBase> Auth) {
+	virtual EModRet OnLoginAttempt(std::shared_ptr<CAuthBase> Auth) {
 		const CString& sUsername = Auth->GetUsername();
 		const CString& sPassword = Auth->GetPassword();
 		CUser *pUser(CZNC::Get().FindUser(sUsername));


### PR DESCRIPTION
The CSmartPtr class was removed from upstream ZNC in 2014 (62328b2c)
This patch allows the module to compile against builds more recent
than that (such as those found in Debian 9).

Sorry for the delay in sending this pull request. Testing it took longer than expected :)